### PR TITLE
chore: remove auto build triggers from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,7 @@
 name: Build Boards
 
 on:
-  push:
-    branches:
-      - main
-      - ci/* # for ci test
-  pull_request:
-    branches:
-      - main
-  workflow_dispatch: # Manual trigger
+  workflow_dispatch: # Manual trigger only
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Remove push/pull_request triggers from build workflow
- Build now only runs manually via workflow_dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)