### PR TITLE
refactor: improve task success evaluation and tighten skill crystallization

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -949,6 +949,15 @@ menu "MCP Client Configuration"
             Endpoint name used as HTTP path: POST /<endpoint>.
             Also used as prefix for local tool names.
 
+    config MIMI_MCP_REMOTE_TENANT_ID
+        int "Remote MCP tenant ID"
+        default 0
+        depends on MIMI_MCP_CLIENT_ENABLE
+        help
+            Tenant ID to embed in the MCP skill prompt.
+            The LLM will automatically include this value when calling alarm tools.
+            Set to 0 to disable (caller must supply tenant_id manually).
+
     config MIMI_MCP_TIMEOUT_MS
         int "MCP tool call timeout (ms)"
         range 1000 60000

--- a/main/mimi/agent/agent_loop.c
+++ b/main/mimi/agent/agent_loop.c
@@ -191,7 +191,7 @@ static void agent_loop_task(void *arg)
             }
         } else {
             /* Evaluate task success using learning hooks */
-            bool task_success = learning_hook_evaluate(result->final_content, result->tool_sequence_json);
+            bool task_success = learning_hook_evaluate(result->final_content, result->tool_sequence_json, result->stop_reason);
             result->task_success = task_success;
 
             /* Save to session */

--- a/main/mimi/agent/context_builder.c
+++ b/main/mimi/agent/context_builder.c
@@ -148,13 +148,7 @@ static size_t append_tools_section(char *buf, size_t size, size_t offset)
             skills[i].description);
     }
 
-    off += snprintf(buf + offset + off, size - offset - off,
-        "\n"
-        "Other tools:\n"
-        "- read_file: Read a file from FATFS.\n"
-        "- write_file: Write/overwrite a file.\n"
-        "- edit_file: Find-and-replace edit.\n"
-        "- list_dir: List files in a directory.\n\n");
+    off += snprintf(buf + offset + off, size - offset - off, "\n");
 
     return off;
 }

--- a/main/mimi/agent/hook.h
+++ b/main/mimi/agent/hook.h
@@ -23,8 +23,8 @@ typedef struct {
     void (*after_tool_execute)(const char *tool_name, const char *result, bool success);
 
     /* Closed-loop learning hooks (Hermes Agent) */
-    /** Evaluate task success based on final output and tool sequence */
-    bool (*evaluate_task_result)(const char *final_output, const char *tool_sequence_json);
+    /** Evaluate task success based on final output, tool sequence, and stop reason */
+    bool (*evaluate_task_result)(const char *final_output, const char *tool_sequence_json, const char *stop_reason);
 
     /** Called when a task ends - update metadata, check crystallization */
     void (*on_task_end)(const char *chat_id, const void *result);

--- a/main/mimi/agent/learning_hooks.c
+++ b/main/mimi/agent/learning_hooks.c
@@ -10,29 +10,10 @@
 
 static const char *TAG = "learning";
 
-/* ─── Failure keywords in output ────────────────────────────────────── */
-
-static const char *failure_keywords[] = {
-    "error", "failed", "sorry", "cannot", "unable", "don't know",
-    "couldn't", "wouldn't", "invalid", "not found", "exception",
-    NULL
-};
-
-static bool contains_failure_keywords(const char *output)
-{
-    if (!output) return false;
-
-    for (int i = 0; failure_keywords[i]; i++) {
-        if (strstr(output, failure_keywords[i])) {
-            return true;
-        }
-    }
-    return false;
-}
-
 /* ─── Public API ──────────────────────────────────────────────────────── */
 
-bool learning_hook_evaluate(const char *final_output, const char *tool_sequence_json)
+bool learning_hook_evaluate(const char *final_output, const char *tool_sequence_json,
+                            const char *stop_reason)
 {
     /* Check final_output is non-empty */
     if (!final_output || !final_output[0]) {
@@ -40,19 +21,18 @@ bool learning_hook_evaluate(const char *final_output, const char *tool_sequence_
         return false;
     }
 
-    /* Check for failure keywords */
-    if (contains_failure_keywords(final_output)) {
-        ESP_LOGI(TAG, "Evaluate: failure keywords found -> false");
+    /* Primary signal: stop_reason must be "completed" */
+    if (!stop_reason || strcmp(stop_reason, "completed") != 0) {
+        ESP_LOGI(TAG, "Evaluate: stop_reason=%s -> false", stop_reason ? stop_reason : "null");
         return false;
     }
 
-    /* Check tool_sequence_json is non-empty */
+    /* Must have at least one tool call */
     if (!tool_sequence_json || !tool_sequence_json[0]) {
         ESP_LOGI(TAG, "Evaluate: no tool sequence -> false");
         return false;
     }
 
-    /* Must have at least one tool call in the JSON */
     cJSON *arr = cJSON_Parse(tool_sequence_json);
     if (!arr || !cJSON_IsArray(arr) || cJSON_GetArraySize(arr) == 0) {
         ESP_LOGI(TAG, "Evaluate: invalid or empty tool sequence JSON -> false");
@@ -61,7 +41,7 @@ bool learning_hook_evaluate(const char *final_output, const char *tool_sequence_
     }
     cJSON_Delete(arr);
 
-    ESP_LOGI(TAG, "Evaluate: task succeeded");
+    ESP_LOGI(TAG, "Evaluate: task succeeded (stop_reason=%s)", stop_reason);
     return true;
 }
 
@@ -94,7 +74,8 @@ void learning_hook_on_task_end(const char *chat_id, const void *result)
         crystallize_context_t ctx = {
             .last_task_success = true,
             .step_count = r->tool_sequence_len,
-            .is_repetitive = false,  /* TODO: detect repetitive tasks */
+            .is_repetitive = r->user_intent ?
+            skill_meta_similar_exists_jaccard(r->user_intent, (char[64]){0}, 64) : false,
             .user_intent = r->user_intent,
             .tool_sequence_json = r->tool_sequence_json,
             .sequence_len = r->tool_sequence_len,

--- a/main/mimi/agent/learning_hooks.h
+++ b/main/mimi/agent/learning_hooks.h
@@ -14,18 +14,20 @@
  */
 
 /**
- * Evaluate whether a task succeeded based on final output and tool sequence.
+ * Evaluate whether a task succeeded based on stop_reason, final output, and tool sequence.
  *
  * Success criteria:
  * - final_output is non-empty
- * - final_output doesn't contain failure keywords (error, failed, sorry, cannot, unable)
+ * - stop_reason is "completed" (primary signal)
  * - tool_sequence_json is non-empty (at least one tool was called)
  *
  * @param final_output       The final assistant response
  * @param tool_sequence_json JSON array of tool calls made during the task
+ * @param stop_reason        Agent stop reason: "completed", "error", or "max_iterations"
  * @return true if task succeeded
  */
-bool learning_hook_evaluate(const char *final_output, const char *tool_sequence_json);
+bool learning_hook_evaluate(const char *final_output, const char *tool_sequence_json,
+                            const char *stop_reason);
 
 /**
  * Called when a task ends. Updates skill metadata and checks for crystallization.

--- a/main/mimi/mimi.c
+++ b/main/mimi/mimi.c
@@ -114,10 +114,23 @@ static esp_err_t init_fatfs(void)
     }
 
     /* Always overwrite built-in skill files from default_skills.h */
-    remove(MIMI_SKILLS_PREFIX "lua-scripts/SKILL.md");
-    remove(MIMI_SKILLS_PREFIX "mcp-servers/SKILL.md");
-    fatfs_ensure_file(MIMI_SKILLS_PREFIX "lua-scripts/SKILL.md", DEFAULT_LUA_SCRIPTS_SKILL);
-    fatfs_ensure_file(MIMI_SKILLS_PREFIX "mcp-servers/SKILL.md", DEFAULT_MCP_SERVERS_SKILL);
+    {
+        static const struct { const char *path; const char *content; } builtin_skills[] = {
+            { MIMI_SKILLS_PREFIX "lua-scripts/SKILL.md", DEFAULT_LUA_SCRIPTS_SKILL },
+            { MIMI_SKILLS_PREFIX "mcp-servers/SKILL.md", DEFAULT_MCP_SERVERS_SKILL },
+            { NULL, NULL }
+        };
+        for (int i = 0; builtin_skills[i].path != NULL; i++) {
+            FILE *f = fopen(builtin_skills[i].path, "w");
+            if (f) {
+                fwrite(builtin_skills[i].content, 1, strlen(builtin_skills[i].content), f);
+                fclose(f);
+                ESP_LOGI(TAG, "Wrote built-in skill: %s", builtin_skills[i].path);
+            } else {
+                ESP_LOGE(TAG, "Failed to write skill: %s", builtin_skills[i].path);
+            }
+        }
+    }
 
     ESP_LOGI(TAG, "Default files initialized");
     return ESP_OK;

--- a/main/mimi/mimi.c
+++ b/main/mimi/mimi.c
@@ -95,8 +95,6 @@ static esp_err_t init_fatfs(void)
         MIMI_FATFS_CONFIG_DIR "/USER.md",
         MIMI_FATFS_BASE "/cron.json",
         MIMI_FATFS_BASE "/HEARTBEAT.md",
-        MIMI_SKILLS_PREFIX "lua-scripts/SKILL.md",
-        MIMI_SKILLS_PREFIX "mcp-servers/SKILL.md",
         NULL
     };
 
@@ -108,14 +106,18 @@ static esp_err_t init_fatfs(void)
         "",                         // USER.md
         "{}",                       // cron.json
         "",                         // HEARTBEAT.md
-        DEFAULT_LUA_SCRIPTS_SKILL, // lua-scripts/SKILL.md
-        DEFAULT_MCP_SERVERS_SKILL, // mcp-servers/SKILL.md
         NULL
     };
 
     for (int i = 0; default_files[i] != NULL; i++) {
         fatfs_ensure_file(default_files[i], default_contents[i]);
     }
+
+    /* Always overwrite built-in skill files from default_skills.h */
+    remove(MIMI_SKILLS_PREFIX "lua-scripts/SKILL.md");
+    remove(MIMI_SKILLS_PREFIX "mcp-servers/SKILL.md");
+    fatfs_ensure_file(MIMI_SKILLS_PREFIX "lua-scripts/SKILL.md", DEFAULT_LUA_SCRIPTS_SKILL);
+    fatfs_ensure_file(MIMI_SKILLS_PREFIX "mcp-servers/SKILL.md", DEFAULT_MCP_SERVERS_SKILL);
 
     ESP_LOGI(TAG, "Default files initialized");
     return ESP_OK;

--- a/main/mimi/mimi.c
+++ b/main/mimi/mimi.c
@@ -114,23 +114,8 @@ static esp_err_t init_fatfs(void)
     }
 
     /* Always overwrite built-in skill files from default_skills.h */
-    {
-        static const struct { const char *path; const char *content; } builtin_skills[] = {
-            { MIMI_SKILLS_PREFIX "lua-scripts/SKILL.md", DEFAULT_LUA_SCRIPTS_SKILL },
-            { MIMI_SKILLS_PREFIX "mcp-servers/SKILL.md", DEFAULT_MCP_SERVERS_SKILL },
-            { NULL, NULL }
-        };
-        for (int i = 0; builtin_skills[i].path != NULL; i++) {
-            FILE *f = fopen(builtin_skills[i].path, "w");
-            if (f) {
-                fwrite(builtin_skills[i].content, 1, strlen(builtin_skills[i].content), f);
-                fclose(f);
-                ESP_LOGI(TAG, "Wrote built-in skill: %s", builtin_skills[i].path);
-            } else {
-                ESP_LOGE(TAG, "Failed to write skill: %s", builtin_skills[i].path);
-            }
-        }
-    }
+    fatfs_write_atomic(MIMI_SKILLS_PREFIX "lua-scripts/SKILL.md", DEFAULT_LUA_SCRIPTS_SKILL, strlen(DEFAULT_LUA_SCRIPTS_SKILL));
+    fatfs_write_atomic(MIMI_SKILLS_PREFIX "mcp-servers/SKILL.md", DEFAULT_MCP_SERVERS_SKILL, strlen(DEFAULT_MCP_SERVERS_SKILL));
 
     ESP_LOGI(TAG, "Default files initialized");
     return ESP_OK;

--- a/main/mimi/skills/default_skills.h
+++ b/main/mimi/skills/default_skills.h
@@ -2,6 +2,10 @@
 
 /* Default SKILL.md content for built-in skills */
 
+/* Stringification helpers for embedding Kconfig values */
+#define _MCP_STR(x) #x
+#define _MCP_XSTR(x) _MCP_STR(x)
+
 #define DEFAULT_LUA_SCRIPTS_SKILL \
     "---\n" \
     "name: lua-scripts\n" \
@@ -9,24 +13,32 @@
     "always: false\n" \
     "---\n" \
     "# Lua Scripts\n\n" \
-    "Execute Lua scripts stored on SPIFFS or run dynamic Lua code snippets.\n\n" \
+    "Execute Lua scripts stored on FATFS or run dynamic Lua code snippets.\n\n" \
     "## Available Tools\n\n" \
     "| Tool | Purpose |\n" \
     "|------|----------|\n" \
-    "| lua_run | Execute a stored Lua script from SPIFFS |\n" \
+    "| lua_run | Execute a stored Lua script from FATFS |\n" \
     "| lua_eval | Execute a Lua code string directly |\n\n" \
     "## Built-in Modules\n\n" \
-    "### socket.http\n" \
+    "### socket.http\n\n" \
+    "HTTP client module.\n\n" \
     "```lua\n" \
-    "local http = require(\"socket.http\")\n" \
-    "local response, status = http.get(url)\n" \
-    "local response, status = http.post(url, body, content_type)\n" \
+    "local http = require(\"socket.http\")\n\n" \
+    "-- GET: returns response body, status code\n" \
+    "local body, status = http.get(url)\n\n" \
+    "-- POST: returns response body, status code\n" \
+    "local body, status = http.post(url, payload, content_type)\n\n" \
+    "-- General request (GET/POST/PUT/DELETE)\n" \
+    "local body, status = http.request(url)\n" \
+    "local body, status = http.request{url=url, method=\"POST\", body=data}\n" \
     "```\n\n" \
-    "### cjson\n" \
+    "### cjson\n\n" \
+    "JSON encode/decode.\n\n" \
     "```lua\n" \
     "local cjson = require(\"cjson\")\n" \
     "local json_str = cjson.encode({key = \"value\"})\n" \
     "local obj = cjson.decode(json_str)\n" \
+    "print(obj.key)\n" \
     "```\n"
 
 #define DEFAULT_MCP_SERVERS_SKILL \
@@ -48,4 +60,7 @@
     "1. Connect: `mcp_connect` with `{\"server_name\": \"default\"}`\n" \
     "2. Discover: `mcp_server.tools_list`\n" \
     "3. Call: `mcp_server.tools_call` with `{\"name\": \"tool_name\", \"arguments\": {...}}`\n" \
-    "4. Disconnect: `mcp_disconnect` when done\n"
+    "4. Disconnect: `mcp_disconnect` when done\n\n" \
+    "## Important\n\n" \
+    "When calling any remote tool via mcp_server.tools_call, " \
+    "always include tenant_id=" _MCP_XSTR(CONFIG_MIMI_MCP_REMOTE_TENANT_ID) " in the arguments.\n"

--- a/main/mimi/skills/default_skills.h
+++ b/main/mimi/skills/default_skills.h
@@ -48,7 +48,10 @@
     "always: true\n" \
     "---\n\n" \
     "# MCP Servers\n\n" \
-    "Connect to MCP servers to use remote tools.\n\n" \
+    "## IMPORTANT: tenant_id Required\n\n" \
+    "ALL remote MCP tools require `tenant_id` as a parameter. " \
+    "You MUST include \"tenant_id\": " _MCP_XSTR(CONFIG_MIMI_MCP_REMOTE_TENANT_ID) " in every tool call's arguments. " \
+    "This applies to both direct tool calls and mcp_server.tools_call.\n\n" \
     "## Available Tools\n\n" \
     "| Tool | When to Use |\n" \
     "|------|------------|\n" \
@@ -59,8 +62,5 @@
     "## How to Use\n\n" \
     "1. Connect: `mcp_connect` with `{\"server_name\": \"default\"}`\n" \
     "2. Discover: `mcp_server.tools_list`\n" \
-    "3. Call: `mcp_server.tools_call` with `{\"name\": \"tool_name\", \"arguments\": {...}}`\n" \
-    "4. Disconnect: `mcp_disconnect` when done\n\n" \
-    "## Important\n\n" \
-    "When calling any remote tool via mcp_server.tools_call, " \
-    "always include tenant_id=" _MCP_XSTR(CONFIG_MIMI_MCP_REMOTE_TENANT_ID) " in the arguments.\n"
+    "3. Call: `mcp_server.tools_call` with `{\"name\": \"tool_name\", \"arguments\": {\"tenant_id\": " _MCP_XSTR(CONFIG_MIMI_MCP_REMOTE_TENANT_ID) ", ...}}`\n" \
+    "4. Disconnect: `mcp_disconnect` when done\n"

--- a/main/mimi/skills/skill_crystallize.c
+++ b/main/mimi/skills/skill_crystallize.c
@@ -143,8 +143,8 @@ bool skill_crystallize_should_create(const crystallize_context_t *ctx)
     }
 
     /* Must have more than one step */
-    if (ctx->step_count < 2) {
-        ESP_LOGI(TAG, "Crystallize skipped: step_count=%d (need >= 2)", ctx->step_count);
+    if (ctx->step_count < 4) {
+        ESP_LOGI(TAG, "Crystallize skipped: step_count=%d (need >= 4)", ctx->step_count);
         return false;
     }
 

--- a/main/mimi/skills/skill_meta.c
+++ b/main/mimi/skills/skill_meta.c
@@ -474,7 +474,13 @@ size_t skill_meta_get_all_auto_skills(char *buf, size_t size)
             /* Safety: verify file exists and check size before reading */
             struct stat st;
             if (stat(s_skills[i].path, &st) != 0) {
-                ESP_LOGW(TAG, "skill file stat failed: %s", s_skills[i].path);
+                ESP_LOGW(TAG, "skill file missing, removing stale entry: %s", s_skills[i].path);
+                memmove(&s_skills[i], &s_skills[i + 1],
+                        (s_skill_count - i - 1) * sizeof(skill_meta_t));
+                s_skill_count--;
+                count--;
+                i--;
+                save_to_file();
                 continue;
             }
             if (st.st_size > SKILL_BUFFER_SIZE - 1) {

--- a/main/mimi/skills/skill_meta.h
+++ b/main/mimi/skills/skill_meta.h
@@ -45,7 +45,7 @@
  * Minimum quality score threshold for crystallization.
  * Skills with quality below this are not crystallized.
  */
-#define SKILL_QUALITY_THRESHOLD_MIN 30
+#define SKILL_QUALITY_THRESHOLD_MIN 60
 
 /**
  * Skill metadata structure for tracking usage and success rates.

--- a/main/mimi/tools/lua_socket_http.c
+++ b/main/mimi/tools/lua_socket_http.c
@@ -195,18 +195,12 @@ static int socket_http_request(lua_State *L)
 }
 
 /**
- * @brief Create socket table with http subtable
- * Creates: socket = {http = {request, get, post, ...}}
+ * @brief Create http table with request, get, post, etc.
  */
-static int luaopen_socket_socket(lua_State *L)
+static void create_http_table(lua_State *L)
 {
-    /* Create socket table */
     lua_newtable(L);
 
-    /* Create socket.http table */
-    lua_newtable(L);
-
-    /* Register functions in socket.http */
     lua_pushcfunction(L, socket_http_request);
     lua_setfield(L, -2, "request");
 
@@ -216,24 +210,19 @@ static int luaopen_socket_socket(lua_State *L)
     lua_pushcfunction(L, socket_http_post);
     lua_setfield(L, -2, "post");
 
-    /* Also add PUT and DELETE for convenience */
     lua_pushcfunction(L, socket_http_request);
     lua_setfield(L, -2, "put");
 
     lua_pushcfunction(L, socket_http_request);
     lua_setfield(L, -2, "delete");
-
-    /* Set socket.http as field of socket */
-    lua_setfield(L, -2, "http");
-
-    return 1;
 }
 
 /**
- * @brief socket module entry point
- * Returns socket table with http subtable
+ * @brief socket.http module entry point
+ * Returns http table: {request, get, post, put, delete}
  */
-int luaopen_socket(lua_State *L)
+int luaopen_socket_http(lua_State *L)
 {
-    return luaopen_socket_socket(L);
+    create_http_table(L);
+    return 1;
 }

--- a/main/mimi/tools/lua_socket_http.h
+++ b/main/mimi/tools/lua_socket_http.h
@@ -3,7 +3,6 @@
  * @brief socket.http Lua module header
  *
  * Provides LuaSocket-compatible HTTP client API.
- * Wraps the existing lua_http_request function.
  */
 
 #pragma once
@@ -13,8 +12,8 @@
 #include <lauxlib.h>
 
 /**
- * @brief socket module entry point
+ * @brief socket.http module entry point
  * @param L Lua state
- * @return Number of values returned on stack (1 - the socket table with http subtable)
+ * @return 1 - the http table with get, post, request, etc.
  */
-int luaopen_socket(lua_State *L);
+int luaopen_socket_http(lua_State *L);

--- a/main/mimi/tools/tool_lua.c
+++ b/main/mimi/tools/tool_lua.c
@@ -12,136 +12,20 @@
 #include "cJSON.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <lua.h>
 #include <lualib.h>
 #include <lauxlib.h>
 
 #include "esp_log.h"
-#include "esp_vfs.h"
-#include "esp_http_client.h"
-#include "esp_crt_bundle.h"
 #include "esp_heap_caps.h"
 
 #include "lua_cjson.h"
 #include "lua_socket_http.h"
 
 static const char *TAG = "lua";
-
-/* ── HTTP response buffer ─────────────────────────────────────── */
-
-typedef struct {
-    char *data;
-    size_t len;
-    size_t cap;
-    bool truncated;
-} http_buf_t;
-
-static esp_err_t http_event_handler(esp_http_client_event_t *evt)
-{
-    http_buf_t *hb = (http_buf_t *)evt->user_data;
-    if (evt->event_id == HTTP_EVENT_ON_DATA) {
-        size_t needed = hb->len + evt->data_len;
-        if (needed >= hb->cap) {
-            hb->truncated = true;
-            /* Copy what we can */
-            size_t copy_len = hb->cap - hb->len - 1;
-            if (copy_len > 0) {
-                memcpy(hb->data + hb->len, evt->data, copy_len);
-                hb->len += copy_len;
-                hb->data[hb->len] = '\0';
-            }
-        } else {
-            memcpy(hb->data + hb->len, evt->data, evt->data_len);
-            hb->len += evt->data_len;
-            hb->data[hb->len] = '\0';
-        }
-    }
-    return ESP_OK;
-}
-
-#define HTTP_BUF_SIZE  (16 * 1024)
-
-static int lua_http_request(lua_State *L, const char *method)
-{
-    const char *url = luaL_checkstring(L, 1);
-    const char *body = (lua_gettop(L) >= 2) ? luaL_checkstring(L, 2) : NULL;
-    const char *content_type = (lua_gettop(L) >= 3) ? luaL_optstring(L, 3, "text/plain") : NULL;
-
-    http_buf_t hb = {0};
-    hb.data = heap_caps_calloc(1, HTTP_BUF_SIZE, MALLOC_CAP_SPIRAM);
-    if (!hb.data) {
-        return luaL_error(L, "out of memory");
-    }
-    hb.cap = HTTP_BUF_SIZE;
-
-    esp_http_client_method_t client_method = HTTP_METHOD_GET;
-    if (strcmp(method, "POST") == 0) client_method = HTTP_METHOD_POST;
-    else if (strcmp(method, "PUT") == 0) client_method = HTTP_METHOD_PUT;
-    else if (strcmp(method, "DELETE") == 0) client_method = HTTP_METHOD_DELETE;
-
-    esp_http_client_config_t config = {
-        .url = url,
-        .event_handler = http_event_handler,
-        .user_data = &hb,
-        .timeout_ms = 15000,
-        .buffer_size = 4096,
-        .crt_bundle_attach = esp_crt_bundle_attach,
-    };
-
-    esp_http_client_handle_t client = esp_http_client_init(&config);
-    if (!client) {
-        free(hb.data);
-        return luaL_error(L, "failed to init HTTP client");
-    }
-
-    if (body) {
-        esp_http_client_set_method(client, client_method);
-        esp_http_client_set_header(client, "Content-Type", content_type);
-        esp_http_client_set_post_field(client, body, strlen(body));
-    } else if (strcmp(method, "DELETE") == 0) {
-        esp_http_client_set_method(client, HTTP_METHOD_DELETE);
-    }
-
-    esp_err_t err = esp_http_client_perform(client);
-    int status = esp_http_client_get_status_code(client);
-    esp_http_client_cleanup(client);
-
-    if (err != ESP_OK) {
-        free(hb.data);
-        return luaL_error(L, "HTTP request failed: %s", esp_err_to_name(err));
-    }
-
-    if (hb.truncated) {
-        free(hb.data);
-        return luaL_error(L, "HTTP response truncated (exceeded %d bytes)", HTTP_BUF_SIZE);
-    }
-
-    lua_pushstring(L, hb.data);
-    lua_pushinteger(L, status);
-    free(hb.data);
-    return 2;
-}
-
-static int lua_http_get(lua_State *L)
-{
-    return lua_http_request(L, "GET");
-}
-
-static int lua_http_post(lua_State *L)
-{
-    return lua_http_request(L, "POST");
-}
-
-static int lua_http_put(lua_State *L)
-{
-    return lua_http_request(L, "PUT");
-}
-
-static int lua_http_delete(lua_State *L)
-{
-    return lua_http_request(L, "DELETE");
-}
 
 /* Output buffer size for Lua results */
 #define LUA_OUTPUT_SIZE 4096
@@ -180,143 +64,6 @@ static int lua_print_wrapper(lua_State *L)
 }
 
 /**
- * @brief Escape string for JSON output
- * @param dst Destination buffer
- * @param dst_size Destination buffer size
- * @param src Source string
- * @return Number of bytes written
- */
-static size_t json_escape_string(char *dst, size_t dst_size, const char *src)
-{
-    size_t i = 0;
-    size_t j = 0;
-    while (src[i] && j < dst_size - 1) {
-        switch (src[i]) {
-            case '"':
-                if (j + 2 < dst_size) { dst[j++] = '\\'; dst[j++] = '"'; }
-                else goto end;
-                break;
-            case '\\':
-                if (j + 2 < dst_size) { dst[j++] = '\\'; dst[j++] = '\\'; }
-                else goto end;
-                break;
-            case '\n':
-                if (j + 2 < dst_size) { dst[j++] = '\\'; dst[j++] = 'n'; }
-                else goto end;
-                break;
-            case '\r':
-                if (j + 2 < dst_size) { dst[j++] = '\\'; dst[j++] = 'r'; }
-                else goto end;
-                break;
-            case '\t':
-                if (j + 2 < dst_size) { dst[j++] = '\\'; dst[j++] = 't'; }
-                else goto end;
-                break;
-            default:
-                dst[j++] = src[i];
-                break;
-        }
-        i++;
-    }
-end:
-    dst[j] = '\0';
-    return j;
-}
-
-/**
- * @brief Serialize a single Lua value to JSON
- * @param L Lua state
- * @param idx Stack index
- * @param buf Output buffer
- * @param size Buffer size
- * @param is_string Whether this is being serialized as array/string context
- */
-static void serialize_lua_value(lua_State *L, int idx, char *buf, size_t size, bool *first)
-{
-    int type = lua_type(L, idx);
-    char temp[256];
-
-    switch (type) {
-        case LUA_TSTRING: {
-            const char *s = lua_tostring(L, idx);
-            if (s) {
-                json_escape_string(temp, sizeof(temp), s);
-                int written = snprintf(buf, size, "%s\"%s\"", *first ? "" : ", ", temp);
-                if (written > 0 && (size_t)written < size) {
-                    *first = false;
-                }
-            }
-            break;
-        }
-        case LUA_TNUMBER:
-            if (lua_isinteger(L, idx)) {
-                snprintf(buf, size, "%s%d", *first ? "" : ", ", (int)lua_tointeger(L, idx));
-            } else {
-                snprintf(buf, size, "%s%.6g", *first ? "" : ", ", lua_tonumber(L, idx));
-            }
-            *first = false;
-            break;
-        case LUA_TBOOLEAN:
-            snprintf(buf, size, "%s%s", *first ? "" : ", ",
-                     lua_toboolean(L, idx) ? "true" : "false");
-            *first = false;
-            break;
-        case LUA_TNIL:
-            snprintf(buf, size, "%snil", *first ? "" : ", ");
-            *first = false;
-            break;
-        default:
-            snprintf(buf, size, "%s[%s]", *first ? "" : ", ", lua_typename(L, type));
-            *first = false;
-            break;
-    }
-}
-
-/**
- * @brief Serialize all return values from Lua stack to JSON array
- * @param L Lua state
- * @param output Output buffer
- * @param output_size Buffer size
- * @return ESP_OK on success
- */
-static esp_err_t serialize_lua_results(lua_State *L, char *output, size_t output_size)
-{
-    int n = lua_gettop(L);
-    if (n == 0) {
-        snprintf(output, output_size, "{\"result\": null}");
-        return ESP_OK;
-    }
-
-    char *buf = output;
-    size_t remaining = output_size;
-    int written = snprintf(buf, remaining, "{\"result\": [");
-    if (written < 0 || (size_t)written >= remaining) {
-        return ESP_ERR_NO_MEM;
-    }
-    buf += written;
-    remaining -= written;
-
-    bool first = true;
-    for (int i = 1; i <= n; i++) {
-        serialize_lua_value(L, i, buf, remaining, &first);
-        size_t len = strlen(buf);
-        buf += len;
-        remaining -= len;
-        if (remaining == 0) break;
-    }
-
-    /* Close array and object */
-    if (remaining >= 3) {
-        snprintf(buf, remaining, "]}");
-    } else {
-        output[output_size - 1] = '\0';
-    }
-
-    lua_pop(L, n);
-    return ESP_OK;
-}
-
-/**
  * @brief Create and configure a Lua state
  */
 static lua_State *create_lua_state(void)
@@ -333,18 +80,12 @@ static lua_State *create_lua_state(void)
     luaL_requiref(L, "cjson", luaopen_cjson, 1);
     lua_pop(L, 1);
 
-    /* Register socket.http module (socket parent table) */
-    luaL_requiref(L, "socket", luaopen_socket, 1);
+    /* Register socket.http module */
+    luaL_requiref(L, "socket.http", luaopen_socket_http, 0);
     lua_pop(L, 1);
 
     /* Register print wrapper */
     lua_register(L, "print", lua_print_wrapper);
-
-    /* Register HTTP wrappers (legacy API, kept for backward compatibility) */
-    lua_register(L, "http_get", lua_http_get);
-    lua_register(L, "http_post", lua_http_post);
-    lua_register(L, "http_put", lua_http_put);
-    lua_register(L, "http_delete", lua_http_delete);
 
     /* Set package.path to include common locations */
     const char *path_setup = "package.path = package.path .. ';/fatfs/lua/?.lua;/fatfs/?.lua;./?.lua'";
@@ -364,11 +105,61 @@ static bool is_path_safe(const char *path)
     if (strncmp(path, MIMI_FATFS_BASE, strlen(MIMI_FATFS_BASE)) != 0) {
         return false;
     }
-    /* Check for path traversal attempts */
     if (strstr(path, "..") != NULL) {
         return false;
     }
     return true;
+}
+
+/**
+ * @brief Serialize Lua stack values to JSON using cjson module
+ *
+ * Uses cjson.encode() to convert Lua values to JSON, then wraps
+ * in {"result": [...]} format.
+ */
+static esp_err_t serialize_lua_results(lua_State *L, char *output, size_t output_size)
+{
+    int n = lua_gettop(L);
+    if (n == 0) {
+        snprintf(output, output_size, "{\"result\":null}");
+        return ESP_OK;
+    }
+
+    /* Get cjson.encode function */
+    lua_getglobal(L, "cjson");
+    lua_getfield(L, -1, "encode");
+    lua_remove(L, -2); /* remove cjson table */
+
+    if (n == 1) {
+        /* Single value: encode directly */
+        lua_pushvalue(L, 1);
+        if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
+            snprintf(output, output_size, "{\"error\":\"cjson.encode failed\"}");
+            lua_pop(L, 1);
+            return ESP_ERR_INVALID_STATE;
+        }
+        const char *encoded = lua_tostring(L, -1);
+        snprintf(output, output_size, "{\"result\":%s}", encoded ? encoded : "null");
+        lua_pop(L, 1);
+    } else {
+        /* Multiple values: encode as array */
+        lua_createtable(L, n, 0);
+        for (int i = 1; i <= n; i++) {
+            lua_pushvalue(L, i);
+            lua_seti(L, -2, i);
+        }
+        if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
+            snprintf(output, output_size, "{\"error\":\"cjson.encode failed\"}");
+            lua_pop(L, 1);
+            return ESP_ERR_INVALID_STATE;
+        }
+        const char *encoded = lua_tostring(L, -1);
+        snprintf(output, output_size, "{\"result\":%s}", encoded ? encoded : "[]");
+        lua_pop(L, 1);
+    }
+
+    lua_pop(L, n);
+    return ESP_OK;
 }
 
 /**
@@ -378,9 +169,31 @@ static esp_err_t execute_lua_code(lua_State *L, const char *code, char *output, 
 {
     if (luaL_dostring(L, code) != LUA_OK) {
         const char *err = lua_tostring(L, -1);
-        char escaped[512];
-        json_escape_string(escaped, sizeof(escaped), err ? err : "unknown error");
-        snprintf(output, output_size, "{\"error\": \"%s\"}", escaped);
+        /* Use cJSON to properly escape the error string */
+        cJSON *err_obj = cJSON_CreateString(err ? err : "unknown error");
+        char *escaped = cJSON_PrintUnformatted(err_obj);
+        cJSON_Delete(err_obj);
+        snprintf(output, output_size, "{\"error\":%s}", escaped ? escaped : "\"unknown error\"");
+        free(escaped);
+        lua_pop(L, 1);
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    return serialize_lua_results(L, output, output_size);
+}
+
+/**
+ * @brief Execute a Lua file and capture output
+ */
+static esp_err_t execute_lua_file(lua_State *L, const char *path, char *output, size_t output_size)
+{
+    if (luaL_dofile(L, path) != LUA_OK) {
+        const char *err = lua_tostring(L, -1);
+        cJSON *err_obj = cJSON_CreateString(err ? err : "unknown error");
+        char *escaped = cJSON_PrintUnformatted(err_obj);
+        cJSON_Delete(err_obj);
+        snprintf(output, output_size, "{\"error\":%s}", escaped ? escaped : "\"unknown error\"");
+        free(escaped);
         lua_pop(L, 1);
         return ESP_ERR_INVALID_STATE;
     }
@@ -396,13 +209,13 @@ esp_err_t tool_lua_eval_execute(const char *input_json, char *output, size_t out
 
     cJSON *root = cJSON_Parse(input_json);
     if (!root) {
-        snprintf(output, output_size, "{\"error\": \"invalid JSON\"}");
+        snprintf(output, output_size, "{\"error\":\"invalid JSON\"}");
         return ESP_ERR_INVALID_ARG;
     }
 
     cJSON *code_item = cJSON_GetObjectItem(root, "code");
     if (!code_item || !cJSON_IsString(code_item)) {
-        snprintf(output, output_size, "{\"error\": \"missing 'code' field\"}");
+        snprintf(output, output_size, "{\"error\":\"missing 'code' field\"}");
         cJSON_Delete(root);
         return ESP_ERR_INVALID_ARG;
     }
@@ -412,7 +225,7 @@ esp_err_t tool_lua_eval_execute(const char *input_json, char *output, size_t out
 
     lua_State *L = create_lua_state();
     if (!L) {
-        snprintf(output, output_size, "{\"error\": \"failed to create Lua state\"}");
+        snprintf(output, output_size, "{\"error\":\"failed to create Lua state\"}");
         cJSON_Delete(root);
         return ESP_ERR_NO_MEM;
     }
@@ -433,30 +246,28 @@ esp_err_t tool_lua_run_execute(const char *input_json, char *output, size_t outp
 
     cJSON *root = cJSON_Parse(input_json);
     if (!root) {
-        snprintf(output, output_size, "{\"error\": \"invalid JSON\"}");
+        snprintf(output, output_size, "{\"error\":\"invalid JSON\"}");
         return ESP_ERR_INVALID_ARG;
     }
 
     cJSON *path_item = cJSON_GetObjectItem(root, "path");
     if (!path_item || !cJSON_IsString(path_item)) {
-        snprintf(output, output_size, "{\"error\": \"missing 'path' field\"}");
+        snprintf(output, output_size, "{\"error\":\"missing 'path' field\"}");
         cJSON_Delete(root);
         return ESP_ERR_INVALID_ARG;
     }
 
     const char *path = path_item->valuestring;
 
-    /* Validate path is safe */
     if (!is_path_safe(path)) {
-        snprintf(output, output_size, "{\"error\": \"path must start with %s and not contain '..'\"}", MIMI_FATFS_BASE);
+        snprintf(output, output_size, "{\"error\":\"path must start with %s and not contain '..'\"}", MIMI_FATFS_BASE);
         cJSON_Delete(root);
         return ESP_ERR_INVALID_ARG;
     }
 
-    /* Check if file exists */
     struct stat st;
     if (stat(path, &st) != 0) {
-        snprintf(output, output_size, "{\"error\": \"file not found: %s\"}", path);
+        snprintf(output, output_size, "{\"error\":\"file not found: %s\"}", path);
         cJSON_Delete(root);
         return ESP_ERR_NOT_FOUND;
     }
@@ -465,27 +276,15 @@ esp_err_t tool_lua_run_execute(const char *input_json, char *output, size_t outp
 
     lua_State *L = create_lua_state();
     if (!L) {
-        snprintf(output, output_size, "{\"error\": \"failed to create Lua state\"}");
+        snprintf(output, output_size, "{\"error\":\"failed to create Lua state\"}");
         cJSON_Delete(root);
         return ESP_ERR_NO_MEM;
     }
 
-    if (luaL_dofile(L, path) != LUA_OK) {
-        const char *err = lua_tostring(L, -1);
-        char escaped[512];
-        json_escape_string(escaped, sizeof(escaped), err ? err : "unknown error");
-        snprintf(output, output_size, "{\"error\": \"%s\"}", escaped);
-        lua_pop(L, 1);
-        lua_close(L);
-        cJSON_Delete(root);
-        return ESP_ERR_INVALID_STATE;
-    }
-
-    esp_err_t ret = serialize_lua_results(L, output, output_size);
+    esp_err_t ret = execute_lua_file(L, path, output, output_size);
 
     lua_close(L);
     cJSON_Delete(root);
 
-    ESP_LOGI(TAG, "Lua script executed successfully");
     return ret;
 }

--- a/main/mimi/tools/tool_mcp_client.c
+++ b/main/mimi/tools/tool_mcp_client.c
@@ -441,7 +441,13 @@ static esp_err_t mcp_tool_execute(const char *tool_name, const char *input_json,
     };
 
     atomic_fetch_add(&ctx->pending_responses, 1);
-    ESP_ERROR_CHECK(esp_mcp_mgr_post_tools_call(s_mgr, &req));
+    esp_err_t post_err = esp_mcp_mgr_post_tools_call(s_mgr, &req);
+    if (post_err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_mcp_mgr_post_tools_call failed: %s", esp_err_to_name(post_err));
+        free_sync_ctx(ctx);
+        snprintf(output, output_size, "{\"error\": \"post failed: %s\"}", esp_err_to_name(post_err));
+        return post_err;
+    }
 
     esp_err_t ret = wait_for_response(ctx, s_server_config.timeout_ms);
 

--- a/main/mimi/tools/tool_registry.c
+++ b/main/mimi/tools/tool_registry.c
@@ -34,6 +34,15 @@ static void build_tools_json(void);
 
 esp_err_t tool_registry_add(const mimi_tool_t *tool)
 {
+    /* Check for duplicate - replace existing entry if found */
+    for (int i = 0; i < s_tool_count; i++) {
+        if (strcmp(s_tools[i].name, tool->name) == 0) {
+            s_tools[i] = *tool;
+            ESP_LOGI(TAG, "Replaced tool: %s", tool->name);
+            return ESP_OK;
+        }
+    }
+
     if (s_tool_count >= MAX_TOOLS) {
         ESP_LOGE(TAG, "Tool registry full, cannot add: %s", tool->name);
         return ESP_ERR_NO_MEM;

--- a/main/mimi/util/fatfs_util.c
+++ b/main/mimi/util/fatfs_util.c
@@ -20,26 +20,7 @@ esp_err_t fatfs_ensure_file(const char *path, const char *content)
     }
 
     ESP_LOGI(TAG, "Creating file: %s", path);
-
-    FILE *f = fopen(path, "w");
-    if (!f) {
-        ESP_LOGE(TAG, "Failed to create file: %s", path);
-        return ESP_FAIL;
-    }
-
-    size_t len = strlen(content);
-    if (len > 0) {
-        size_t written = fwrite(content, 1, len, f);
-        if (written != len) {
-            ESP_LOGE(TAG, "Write incomplete: %s (%d/%d bytes)", path, (int)written, (int)len);
-            fclose(f);
-            return ESP_FAIL;
-        }
-    }
-
-    fclose(f);
-    ESP_LOGI(TAG, "File created: %s (%d bytes)", path, (int)len);
-    return ESP_OK;
+    return fatfs_write_atomic(path, content, strlen(content));
 }
 
 esp_err_t fatfs_write_atomic(const char *path, const void *data, size_t len)

--- a/main/mimi/util/fatfs_util.c
+++ b/main/mimi/util/fatfs_util.c
@@ -20,7 +20,26 @@ esp_err_t fatfs_ensure_file(const char *path, const char *content)
     }
 
     ESP_LOGI(TAG, "Creating file: %s", path);
-    return fatfs_write_atomic(path, content, strlen(content));
+
+    FILE *f = fopen(path, "w");
+    if (!f) {
+        ESP_LOGE(TAG, "Failed to create file: %s", path);
+        return ESP_FAIL;
+    }
+
+    size_t len = strlen(content);
+    if (len > 0) {
+        size_t written = fwrite(content, 1, len, f);
+        if (written != len) {
+            ESP_LOGE(TAG, "Write incomplete: %s (%d/%d bytes)", path, (int)written, (int)len);
+            fclose(f);
+            return ESP_FAIL;
+        }
+    }
+
+    fclose(f);
+    ESP_LOGI(TAG, "File created: %s (%d bytes)", path, (int)len);
+    return ESP_OK;
 }
 
 esp_err_t fatfs_write_atomic(const char *path, const void *data, size_t len)


### PR DESCRIPTION
## Summary
- Replace broad failure keyword check with stop_reason-based evaluation
- Raise quality threshold from 30 to 60 and minimum steps from 2 to 4
- Enable repetition detection using Jaccard similarity
- Clean up stale skill_meta entries when FATFS files are missing

## Test plan
- [ ] Verify stop_reason=completed tasks show success=1
- [ ] Verify 2-step non-repetitive tasks no longer trigger crystallization
- [ ] Verify 4+ step tasks still crystallize correctly
- [ ] Verify stale skill entries are cleaned up